### PR TITLE
#49 Fix for windows specific issue in csv reporter and test

### DIFF
--- a/cvtest/csv_reporter.py
+++ b/cvtest/csv_reporter.py
@@ -14,12 +14,12 @@ class CsvReporter:
             rmtree(dir_path)
         os.makedirs(dir_path)
         with open(self.__file_path, 'w') as f:
-            writer = csv.writer(f)
+            writer = csv.writer(f, lineterminator='\n')
             writer.writerow(self.__fields)
 
     def __append(self, values):
         with open(self.__file_path, 'a') as f:
-            writer = csv.writer(f)
+            writer = csv.writer(f, lineterminator='\n')
             writer.writerow(values)
 
     def log_report(self, result):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -33,7 +33,7 @@ def test_report_error():
     assert len(values) == 4
     assert values[-1][0] == 'error.png'
     assert values[-1][1] == 'ERROR'
-    assert values[-1][2] == ROOT_DIR + '/tests/test_reporter.py:40;'
+    assert values[-1][2] == os.path.join(ROOT_DIR, 'tests', 'test_reporter.py:40;')
 
 def process_image(image_path):
     if image_path == "error.png":


### PR DESCRIPTION
This PR tries to resolve the followings:

* Test failures in Windows env due to Windows-specific line-ending and path-separator.
