### PR TITLE
#49 fix: add path separator in save_image

### DIFF
--- a/cvtest/reporter.py
+++ b/cvtest/reporter.py
@@ -32,7 +32,7 @@ class Reporter:
     def __save_image(self, img):
         if not os.path.exists(self.image_path):
             os.makedirs(self.image_path)
-        output_path = self.image_path + str(uuid4()) + '.png'
+        output_path = os.path.join(self.image_path,  str(uuid4()) + '.png')
         cv2.imwrite(output_path, img)
         return output_path
 


### PR DESCRIPTION
I think this is the intended log image location.

![image](https://user-images.githubusercontent.com/46243939/104127629-8cfd0200-53a6-11eb-9bd4-f420479c8b80.png)
